### PR TITLE
Use shellwords to escape passwords

### DIFF
--- a/lib/gocd/config/credentials.rb
+++ b/lib/gocd/config/credentials.rb
@@ -1,3 +1,5 @@
+require 'shellwords'
+
 module GOCD
   class Credentials
     attr_reader :username, :password
@@ -8,7 +10,7 @@ module GOCD
     end
 
     def curl_credentials
-      "#{@username}:#{@password}"
+      Shellwords.escape("#{@username}:#{@password}")
     end
   end
 

--- a/lib/gocd/version.rb
+++ b/lib/gocd/version.rb
@@ -1,3 +1,3 @@
 module GOCD
-  VERSION = '1.2.5'
+  VERSION = '1.2.6'
 end

--- a/spec/gocd/config/credentials_spec.rb
+++ b/spec/gocd/config/credentials_spec.rb
@@ -6,4 +6,9 @@ RSpec.describe GOCD::Credentials, 'credentials' do
     credentials = GOCD::Credentials.new 'admin', 'password'
     expect(credentials.curl_credentials).to eq 'admin:password'
   end
+
+  it '#curl_credentials should be escaped for the command line' do
+    credentials = GOCD::Credentials.new('admin', '"cpF@<`89Q.[cA]C%hj>M<s3\'sl')
+    expect(credentials.curl_credentials).to eq('admin:\"cpF@\<\`89Q.\[cA\]C\%hj\>M\<s3\\\'sl')
+  end
 end


### PR DESCRIPTION
Properly escapes passwords on the command line.