### PR TITLE
Report when a pipeline is building

### DIFF
--- a/lib/gocd/pipeline_status/pipeline.rb
+++ b/lib/gocd/pipeline_status/pipeline.rb
@@ -13,7 +13,7 @@ module GOCD
     end
 
     def status
-      {pipeline: name, status: last_build_status}
+      {pipeline: name, status: current_status}
     end
 
     def red?
@@ -38,6 +38,10 @@ module GOCD
 
     def to_hash
       @pipeline
+    end
+
+    def current_status
+      (@pipeline['activity'] && @pipeline['activity'].downcase == 'sleeping') ? last_build_status : @pipeline['activity']
     end
   end
 end

--- a/spec/gocd/pipeline_status/pipeline_spec.rb
+++ b/spec/gocd/pipeline_status/pipeline_spec.rb
@@ -69,44 +69,34 @@ RSpec.describe GOCD::Pipeline, 'pipeline' do
   end
 
   context 'when a previously successful pipeline is running' do
-    before(:each) do
-      @raw_pipeline = {'name' => 'pipeline 1', 'activity' => 'Building', 'lastBuildStatus' => 'Success'}
-    end
+    let(:raw_pipeline) { {'name' => 'pipeline 1', 'activity' => 'Building', 'lastBuildStatus' => 'Success'} }
 
     it '#status should be building' do
-      @pipeline = GOCD::Pipeline.new @raw_pipeline
-      expect(@pipeline.status).to eq({pipeline: 'pipeline 1', status: 'Building'})
+      expect(GOCD::Pipeline.new(raw_pipeline).status).to eq({pipeline: 'pipeline 1', status: 'Building'})
     end
 
     it '#green? should return true' do
-      @pipeline = GOCD::Pipeline.new @raw_pipeline
-      expect(@pipeline.green?).to be_truthy
+      expect(GOCD::Pipeline.new(raw_pipeline).green?).to be_truthy
     end
 
     it '#red? should return false' do
-      @pipeline = GOCD::Pipeline.new @raw_pipeline
-      expect(@pipeline.red?).to be_falsey
+      expect(GOCD::Pipeline.new(raw_pipeline).red?).to be_falsey
     end
   end
 
   context 'when a previously failed pipeline is running' do
-    before(:each) do
-      @raw_pipeline = {'name' => 'pipeline 1', 'activity' => 'Building', 'lastBuildStatus' => 'Failure'}
-    end
+    let(:raw_pipeline) { {'name' => 'pipeline 1', 'activity' => 'Building', 'lastBuildStatus' => 'Failure'} }
 
     it '#status should be building' do
-      @pipeline = GOCD::Pipeline.new @raw_pipeline
-      expect(@pipeline.status).to eq({pipeline: 'pipeline 1', status: 'Building'})
+      expect(GOCD::Pipeline.new(raw_pipeline).status).to eq({pipeline: 'pipeline 1', status: 'Building'})
     end
 
     it '#green? should return false' do
-      @pipeline = GOCD::Pipeline.new @raw_pipeline
-      expect(@pipeline.green?).to be_falsey
+      expect(GOCD::Pipeline.new(raw_pipeline).green?).to be_falsey
     end
 
     it '#red? should return true' do
-      @pipeline = GOCD::Pipeline.new @raw_pipeline
-      expect(@pipeline.red?).to be_truthy
+      expect(GOCD::Pipeline.new(raw_pipeline).red?).to be_truthy
     end
   end
 end

--- a/spec/gocd/pipeline_status/pipeline_spec.rb
+++ b/spec/gocd/pipeline_status/pipeline_spec.rb
@@ -12,6 +12,11 @@ RSpec.describe GOCD::Pipeline, 'pipeline' do
       expect(@pipeline.name).to eq 'pipeline 1'
     end
 
+    it '#status should be success' do
+      @pipeline = GOCD::Pipeline.new @raw_pipeline
+      expect(@pipeline.status).to eq({pipeline: 'pipeline 1', status: 'Success'})
+    end
+
     it '#last_build_status should return last build status' do
       @pipeline = GOCD::Pipeline.new @raw_pipeline
       expect(@pipeline.last_build_status).to eq 'Success'
@@ -31,6 +36,11 @@ RSpec.describe GOCD::Pipeline, 'pipeline' do
   context 'when last build status is failure' do
     before(:each) do
       @raw_pipeline = {'name' => 'pipeline 1', 'activity' => 'sleeping', 'lastBuildStatus' => 'Failure'}
+    end
+
+    it '#status should be failure' do
+      @pipeline = GOCD::Pipeline.new @raw_pipeline
+      expect(@pipeline.status).to eq({pipeline: 'pipeline 1', status: 'Failure'})
     end
 
     it '#green? should return false' do
@@ -56,5 +66,47 @@ RSpec.describe GOCD::Pipeline, 'pipeline' do
     expect(pipeline.last_build_time).to eq('2017-02-28')
     expect(pipeline.last_build_label).to eq('lable')
     expect(pipeline.to_hash).to eq(@raw_pipeline)
+  end
+
+  context 'when a previously successful pipeline is running' do
+    before(:each) do
+      @raw_pipeline = {'name' => 'pipeline 1', 'activity' => 'Building', 'lastBuildStatus' => 'Success'}
+    end
+
+    it '#status should be building' do
+      @pipeline = GOCD::Pipeline.new @raw_pipeline
+      expect(@pipeline.status).to eq({pipeline: 'pipeline 1', status: 'Building'})
+    end
+
+    it '#green? should return true' do
+      @pipeline = GOCD::Pipeline.new @raw_pipeline
+      expect(@pipeline.green?).to be_truthy
+    end
+
+    it '#red? should return false' do
+      @pipeline = GOCD::Pipeline.new @raw_pipeline
+      expect(@pipeline.red?).to be_falsey
+    end
+  end
+
+  context 'when a previously failed pipeline is running' do
+    before(:each) do
+      @raw_pipeline = {'name' => 'pipeline 1', 'activity' => 'Building', 'lastBuildStatus' => 'Failure'}
+    end
+
+    it '#status should be building' do
+      @pipeline = GOCD::Pipeline.new @raw_pipeline
+      expect(@pipeline.status).to eq({pipeline: 'pipeline 1', status: 'Building'})
+    end
+
+    it '#green? should return false' do
+      @pipeline = GOCD::Pipeline.new @raw_pipeline
+      expect(@pipeline.green?).to be_falsey
+    end
+
+    it '#red? should return true' do
+      @pipeline = GOCD::Pipeline.new @raw_pipeline
+      expect(@pipeline.red?).to be_truthy
+    end
   end
 end


### PR DESCRIPTION
Currently, a pipeline is always reported as 'Success' or 'Failed', depending on the last completed run. A more helpful status would indicate when a pipeline is in progress so I have used the 'activity' information.

**Question:** Are there statuses for activity other than 'Building' and 'Sleeping'? I couldn't find any documentation on this.